### PR TITLE
Add supabase support (auth, db) + Account features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,10 @@ app.*.map.json
 
 #environment variables
 lib/config.dart
+.env*
 
+#supabase local instance
+supabase/
+
+# Extra resources used for this project
 _resources/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["denoland.vscode-deno"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,24 @@
+{
+  "deno.enablePaths": [
+    "supabase/functions"
+  ],
+  "deno.lint": true,
+  "deno.unstable": [
+    "bare-node-builtins",
+    "byonm",
+    "sloppy-imports",
+    "unsafe-proto",
+    "webgpu",
+    "broadcast-channel",
+    "worker-options",
+    "cron",
+    "kv",
+    "ffi",
+    "fs",
+    "http",
+    "net"
+  ],
+  "[typescript]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  }
+}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.lightseed"
+    namespace = "com.lightseed.lightseed"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.lightseed"
+        applicationId = "com.lightseed.lightseed"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.lightseed.lightseed">
+
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <application

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <application
+        android:enableOnBackInvokedCallback="true"
         android:label="LightSeed"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,12 +28,24 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            
+            <!-- DEEP LINKING -->
+            <intent-filter>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <!-- Accepts URIs that begin with YOUR_SCHEME://YOUR_HOST -->
+            <data
+            android:scheme="com.lightseed.lightseed"
+            android:host="login-callback" />
+        </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/kotlin/com/lightseed/lightseed/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/lightseed/lightseed/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.lightseed
+package com.lightseed.lightseed
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - app_links (1.0.0):
-    - FlutterMacOS
+  - app_links (0.0.2):
+    - Flutter
   - AppAuth (1.7.6):
     - AppAuth/Core (= 1.7.6)
     - AppAuth/ExternalUserAgent (= 1.7.6)
   - AppAuth/Core (1.7.6)
   - AppAuth/ExternalUserAgent (1.7.6):
     - AppAuth/Core
-  - FlutterMacOS (1.0.0)
+  - Flutter (1.0.0)
   - google_sign_in_ios (0.0.1):
     - AppAuth (>= 1.7.4)
     - Flutter
@@ -32,16 +32,16 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - url_launcher_macos (0.0.1):
-    - FlutterMacOS
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
-  - app_links (from `Flutter/ephemeral/.symlinks/plugins/app_links/macos`)
-  - FlutterMacOS (from `Flutter/ephemeral`)
-  - google_sign_in_ios (from `Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin`)
-  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
-  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
+  - app_links (from `.symlinks/plugins/app_links/ios`)
+  - Flutter (from `Flutter`)
+  - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
@@ -52,30 +52,30 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   app_links:
-    :path: Flutter/ephemeral/.symlinks/plugins/app_links/macos
-  FlutterMacOS:
-    :path: Flutter/ephemeral
+    :path: ".symlinks/plugins/app_links/ios"
+  Flutter:
+    :path: Flutter
   google_sign_in_ios:
-    :path: Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin
+    :path: ".symlinks/plugins/google_sign_in_ios/darwin"
   path_provider_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   shared_preferences_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
-  url_launcher_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  app_links: 10e0a0ab602ffaf34d142cd4862f29d34b303b2a
+  app_links: e7a6750a915a9e161c58d91bc610e8cd1d4d0ad0
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
-  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   google_sign_in_ios: 07375bfbf2620bc93a602c0e27160d6afc6ead38
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
-PODFILE CHECKSUM: 9ebaf0ce3d369aaa26a9ea0e159195ed94724cf3
+PODFILE CHECKSUM: 7be2f5f74864d463a8ad433546ed1de7e0f29aef
 
 COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,10 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		025973A2EC71E570C7273FC2 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EEAD4CF9C7E62AFCEA1FAD55 /* Pods_Runner.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		927DBCC464A74F1E0D966F6B /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6FC86D51EC00A377CD5C112 /* Pods_RunnerTests.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -42,12 +44,17 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		2192CF8108E3FCF6ECCF95F6 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		649A4C6F2DCB6C9B79B68E2F /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		7A4C485E51393DDAE506D948 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		86B0676E15CB99CB7321DCAC /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		8905EA95A2E293BDF4120600 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -55,6 +62,9 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E6FC86D51EC00A377CD5C112 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECDC3A2EFCE39F4565B3FA91 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		EEAD4CF9C7E62AFCEA1FAD55 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +72,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				025973A2EC71E570C7273FC2 /* Pods_Runner.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9B2021D0C339EE4B511A57B3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				927DBCC464A74F1E0D966F6B /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,6 +93,20 @@
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		35364025F515701464998A4F /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				649A4C6F2DCB6C9B79B68E2F /* Pods-Runner.debug.xcconfig */,
+				2192CF8108E3FCF6ECCF95F6 /* Pods-Runner.release.xcconfig */,
+				7A4C485E51393DDAE506D948 /* Pods-Runner.profile.xcconfig */,
+				86B0676E15CB99CB7321DCAC /* Pods-RunnerTests.debug.xcconfig */,
+				8905EA95A2E293BDF4120600 /* Pods-RunnerTests.release.xcconfig */,
+				ECDC3A2EFCE39F4565B3FA91 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -94,6 +127,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				35364025F515701464998A4F /* Pods */,
+				FD4862672606D852873E87F5 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -121,6 +156,15 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		FD4862672606D852873E87F5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				EEAD4CF9C7E62AFCEA1FAD55 /* Pods_Runner.framework */,
+				E6FC86D51EC00A377CD5C112 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -128,8 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				6AD70DF17BE622CA0A37D447 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				9B2021D0C339EE4B511A57B3 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -145,12 +191,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				05413CC4C94545F7E648EB07 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				12D48A2E5A29E56793947353 /* [CP] Embed Pods Frameworks */,
+				8234A31C0514DACA71F66E53 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -222,6 +271,45 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		05413CC4C94545F7E648EB07 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		12D48A2E5A29E56793947353 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -237,6 +325,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		6AD70DF17BE622CA0A37D447 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		8234A31C0514DACA71F66E53 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -368,7 +495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstFlutterApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lightseed.lightseed;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -378,13 +505,14 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 86B0676E15CB99CB7321DCAC /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstFlutterApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lightseed.lightseed.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -395,13 +523,14 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8905EA95A2E293BDF4120600 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstFlutterApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lightseed.lightseed.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -410,13 +539,14 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = ECDC3A2EFCE39F4565B3FA91 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstFlutterApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lightseed.lightseed.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +677,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstFlutterApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lightseed.lightseed;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +699,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstFlutterApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lightseed.lightseed;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -60,5 +60,18 @@
 			</array>
 		</dict>
 	</array>
+
+	<!-- Add this array for Deep Links -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+		<key>CFBundleTypeRole</key>
+		<string>Editor</string>
+		<key>CFBundleURLSchemes</key>
+		<array>
+			<string>com.lightseed.lightseed</string>
+		</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -51,5 +51,14 @@
         <key>NSAllowsArbitraryLoads</key>
         <true/>
     </dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.847143055036-92prvt6vsb2a84ca4qpnmcoakddipcje</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/lib/config_sample.dart
+++ b/lib/config_sample.dart
@@ -1,1 +1,11 @@
 const String baseUrl = 'YOUR_APPS_SCRIPT_DEPLOYED_WEBAPP_FROM_GOOGLESPREADSHEET_URL_HERE';
+
+const bool isLocal = true;
+
+const supabaseUrl = isLocal
+    ? "http://localhost:54321"
+    : "https://your-cloud-supabase-url.supabase.co";
+
+const supabaseAnonKey = isLocal
+    ? "your-local-anon-key"
+    : "your-cloud-anon-key";

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:lightseed/src/ui/screens/splash_screen.dart';
 import 'package:lightseed/src/ui/app.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:lightseed/config.dart'; // Import the configuration file
 
 
-void main() {
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  await Supabase.initialize(
+    url: supabaseUrl,
+    anonKey: supabaseAnonKey,
+  );
+
   runApp(MyAppWithSplashScreen());
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:lightseed/src/logic/account_state_screen.dart';
 import 'package:lightseed/src/logic/auth_state_listener.dart';
 import 'package:lightseed/src/logic/today_page_state.dart';
 import 'package:lightseed/src/ui/screens/splash_screen.dart';
@@ -19,13 +20,10 @@ Future<void> main() async {
     anonKey: supabaseAnonKey,
   );
   runApp(
-    // I needed to add a multiprovider because without it 
-    // when on the splash screen and the user isn't logged in,
-    // TodayPage is trying to be accessed and I'm getting an Exception that the provider doesn't exist
     MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => TodayPageState()),
-        // Add other providers here if needed
+        ChangeNotifierProvider(create: (_) => AccountState()),
       ],
       child: MyAppWithSplashScreen(),
     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,19 +1,20 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:lightseed/src/logic/account_state_screen.dart';
 import 'package:lightseed/src/logic/auth_state_listener.dart';
 import 'package:lightseed/src/logic/today_page_state.dart';
-import 'package:lightseed/src/ui/screens/splash_screen.dart';
+import 'package:lightseed/src/ui/screens/sign_screen.dart';
 import 'package:lightseed/src/ui/app.dart';
+import 'package:lightseed/src/ui/screens/splash_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:lightseed/config.dart'; // Import the configuration file
-import 'package:flutter_web_plugins/url_strategy.dart'; // For deep links on web, to support Supabase auth
+//import 'package:flutter_web_plugins/url_strategy.dart'; // For deep links on web, to support Supabase auth
 
 
 Future<void> main() async {
-  if (kIsWeb) usePathUrlStrategy();
-  WidgetsFlutterBinding.ensureInitialized();
+  
+  //if (kIsWeb) usePathUrlStrategy();
+  //WidgetsFlutterBinding.ensureInitialized();
 
   await Supabase.initialize(
     url: supabaseUrl,
@@ -30,11 +31,15 @@ Future<void> main() async {
   );
 }
 
+final supabase = Supabase.instance.client;
+
 class MyAppWithSplashScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AuthStateListener(
-      child: buildMaterialApp(context, SplashScreen()),
-    );
+        child: buildMaterialApp(
+          context,
+          supabase.auth.currentSession == null ? SignScreen() : SplashScreen()),
+      );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,9 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lightseed/src/logic/account_state_screen.dart';
 import 'package:lightseed/src/logic/auth_state_listener.dart';
 import 'package:lightseed/src/logic/today_page_state.dart';
-import 'package:lightseed/src/ui/screens/sign_screen.dart';
 import 'package:lightseed/src/ui/app.dart';
-import 'package:lightseed/src/ui/screens/splash_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:lightseed/config.dart'; // Import the configuration file
@@ -37,9 +35,7 @@ class MyAppWithSplashScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AuthStateListener(
-        child: buildMaterialApp(
-          context,
-          supabase.auth.currentSession == null ? SignScreen() : SplashScreen()),
+        child: buildMaterialApp(context),
       );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lightseed/src/logic/auth_logic.dart';
 import 'package:lightseed/src/ui/screens/splash_screen.dart';
 import 'package:lightseed/src/ui/app.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -13,6 +14,22 @@ Future<void> main() async {
     url: supabaseUrl,
     anonKey: supabaseAnonKey,
   );
+
+  // Listen for auth state changes
+  Supabase.instance.client.auth.onAuthStateChange.listen((data) {
+    final AuthChangeEvent event = data.event;
+    final Session? session = data.session;
+    
+    if (event == AuthChangeEvent.signedIn && session != null) {
+      final user = session.user;
+      print('User signed in: ${user.email}');
+      
+      // Optionally, call your function to save additional user data
+      AuthLogic.saveUserData(user);
+    } else if (event == AuthChangeEvent.signedOut) {
+      print('User signed out.');
+    }
+  });
 
   runApp(MyAppWithSplashScreen());
 }

--- a/lib/src/logic/account_state_screen.dart
+++ b/lib/src/logic/account_state_screen.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:lightseed/src/logic/auth_logic.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../models/user.dart';
+
+class AccountState with ChangeNotifier {
+  AppUser? _user;
+
+  AppUser? get user => _user;
+
+  void setUser(AppUser user) {
+    _user = user;
+    notifyListeners();
+  }
+
+  void setUserFromSupabase(User user) {
+    _user = AppUser.fromSupabaseUser(user);
+    notifyListeners();
+  }
+
+  Future<void> saveUserData() async {
+    if (_user != null) {
+      await AuthLogic.saveUserData(_user!);
+    }
+  }
+
+  Future<void> signOut(BuildContext context) async {
+    await AuthLogic.signOut();
+    if (!context.mounted) return;
+    Navigator.pushReplacementNamed(context, '/');
+  }
+}

--- a/lib/src/logic/account_state_screen.dart
+++ b/lib/src/logic/account_state_screen.dart
@@ -13,6 +13,13 @@ class AccountState with ChangeNotifier {
     notifyListeners();
   }
 
+  void updateUserName(String name) {
+    if (user != null) {
+      _user = user!.copyWith(fullName: name);
+      notifyListeners();
+    }
+  }
+
   void setUserFromSupabase(User user) {
     _user = AppUser.fromSupabaseUser(user);
     notifyListeners();

--- a/lib/src/logic/account_state_screen.dart
+++ b/lib/src/logic/account_state_screen.dart
@@ -26,7 +26,10 @@ class AccountState with ChangeNotifier {
 
   Future<void> signOut(BuildContext context) async {
     await AuthLogic.signOut();
-    if (!context.mounted) return;
-    Navigator.pushReplacementNamed(context, '/');
+  }
+
+  void clearUser() {
+    _user = null;
+    notifyListeners();
   }
 }

--- a/lib/src/logic/auth_logic.dart
+++ b/lib/src/logic/auth_logic.dart
@@ -20,8 +20,13 @@ class AuthLogic {
     }
   }
 
-  static Future<String?> signIn(String email, String password) async {
+    static Future<String?> signIn(String email, String password) async {
     try {
+      final currentSession = Supabase.instance.client.auth.currentSession;
+      if (currentSession != null) {
+        return 'User is already logged in!';
+      }
+
       final response = await Supabase.instance.client.auth.signInWithPassword(
         email: email,
         password: password,
@@ -52,6 +57,7 @@ class AuthLogic {
           .upsert({
         'id': user.id, // Matches the id from auth.users
         'email': user.email,
+        'full_name': user.fullName,
         ...user.toSupabaseMetadata(),
       });
 

--- a/lib/src/logic/auth_logic.dart
+++ b/lib/src/logic/auth_logic.dart
@@ -56,7 +56,6 @@ class AuthLogic {
           .from('profiles') // Your custom table to store user data
           .upsert({
         'id': user.id, // Matches the id from auth.users
-        'email': user.email,
         'full_name': user.fullName,
         ...user.toSupabaseMetadata(),
       });

--- a/lib/src/logic/auth_logic.dart
+++ b/lib/src/logic/auth_logic.dart
@@ -1,3 +1,4 @@
+import 'package:lightseed/src/models/user.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class AuthLogic {
@@ -44,15 +45,14 @@ class AuthLogic {
     }
   }
 
-  static Future<void> saveUserData(User user) async {
+  static Future<void> saveUserData(AppUser user) async {
     try {
       final response = await Supabase.instance.client
           .from('profiles') // Your custom table to store user data
           .upsert({
         'id': user.id, // Matches the id from auth.users
         'email': user.email,
-        'full_name': user.userMetadata?['full_name'],
-        'avatar_url': user.userMetadata?['avatar_url'],
+        ...user.toSupabaseMetadata(),
       });
 
       // The new client libraries may throw an exception on error, so you might not get a response.error.
@@ -65,4 +65,14 @@ class AuthLogic {
       print('Error saving user data: $e');
     }
   }
+
+  static Future<void> signOut() async {
+    try {
+      await Supabase.instance.client.auth.signOut();
+      print('User signed out successfully!');
+    } catch (e) {
+      print('Error during sign-out: $e');
+    }
+  }
+  
 }

--- a/lib/src/logic/auth_logic.dart
+++ b/lib/src/logic/auth_logic.dart
@@ -1,0 +1,66 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class AuthLogic {
+  static Future<void> signUp(String email, String password) async {
+    try {
+      final response = await Supabase.instance.client.auth.signUp(
+        email: email,
+        password: password,
+      );
+      if (response.session != null) {
+        print('Error during sign-up: ${response.session.toString()}');
+      } else {
+        print('Sign-up successful!');
+      }
+    } catch (e) {
+      print('Error during sign-up: $e');
+    }
+  }
+
+  static Future<void> signIn(String email, String password) async {
+    try {
+      final response = await Supabase.instance.client.auth.signInWithPassword(
+        email: email,
+        password: password,
+      );
+      if (response.session != null) {
+        print('Error during sign-up: ${response.session.toString()}');
+      } else {
+        print('Sign-in with email and password successful!');
+      }
+    } catch (e) {
+      print('Error during sign-in with email/password: $e');
+    }
+  }
+
+  static Future<void> signInWithGoogle() async {
+    try {
+      // Trigger OAuth Sign-In with Google
+      await Supabase.instance.client.auth.signInWithOAuth(OAuthProvider.google);
+    } catch (e) {
+      print('Error during Google sign-in: $e');
+    }
+  }
+
+  static Future<void> saveUserData(User user) async {
+    try {
+      final response = await Supabase.instance.client
+          .from('profiles') // Your custom table to store user data
+          .upsert({
+        'id': user.id, // Matches the id from auth.users
+        'email': user.email,
+        'full_name': user.userMetadata?['full_name'],
+        'avatar_url': user.userMetadata?['avatar_url'],
+      });
+
+      // The new client libraries may throw an exception on error, so you might not get a response.error.
+      if (response.error != null) {
+        print('Error saving user data: ${response.error!.message}');
+      } else {
+        print('User data saved successfully!');
+      }
+    } catch (e) {
+      print('Error saving user data: $e');
+    }
+  }
+}

--- a/lib/src/logic/auth_logic.dart
+++ b/lib/src/logic/auth_logic.dart
@@ -1,35 +1,37 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class AuthLogic {
-  static Future<void> signUp(String email, String password) async {
+  static Future<String?> signUp(String email, String password) async {
     try {
       final response = await Supabase.instance.client.auth.signUp(
         email: email,
         password: password,
       );
-      if (response.session != null) {
-        print('Error during sign-up: ${response.session.toString()}');
+      if (response.user != null && response.session == null) {
+        return 'Sign-up successful! Please confirm your email.';
+      } else if (response.session != null) {
+        return 'Sign-up successful and user is logged in!';
       } else {
-        print('Sign-up successful!');
+        return 'Sign-up response: ${response.toString()}';
       }
     } catch (e) {
-      print('Error during sign-up: $e');
+      return 'Error during sign-up: $e';
     }
   }
 
-  static Future<void> signIn(String email, String password) async {
+  static Future<String?> signIn(String email, String password) async {
     try {
       final response = await Supabase.instance.client.auth.signInWithPassword(
         email: email,
         password: password,
       );
       if (response.session != null) {
-        print('Error during sign-up: ${response.session.toString()}');
+        return 'Sign-in with email and password successful!';
       } else {
-        print('Sign-in with email and password successful!');
+        return 'Error during sign-in: ${response.toString()}';
       }
     } catch (e) {
-      print('Error during sign-in with email/password: $e');
+      return 'Error during sign-in with email/password: $e';
     }
   }
 

--- a/lib/src/logic/auth_state_listener.dart
+++ b/lib/src/logic/auth_state_listener.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:lightseed/src/ui/screens/main_screen.dart';
-import 'package:lightseed/src/ui/screens/sign_screen.dart';
+import '../shared/router.dart'; // Import the router file
 
 class AuthStateListener extends StatefulWidget {
   final Widget child;
 
-  AuthStateListener({required this.child});
+  const AuthStateListener({required this.child, super.key});
 
   @override
   AuthStateListenerState createState() => AuthStateListenerState();
@@ -22,16 +21,10 @@ class AuthStateListenerState extends State<AuthStateListener> {
 
       if (event == AuthChangeEvent.signedIn && session != null) {
         if (!mounted) return;
-        Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(builder: (context) => MyMainScreen()),
-        );
+        Navigator.pushReplacementNamed(context, AppRoutes.main);
       } else if (event == AuthChangeEvent.signedOut) {
         if (!mounted) return;
-        Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(builder: (context) => SignPage()),
-        );
+        Navigator.pushReplacementNamed(context, AppRoutes.signIn);
       }
     });
   }

--- a/lib/src/logic/auth_state_listener.dart
+++ b/lib/src/logic/auth_state_listener.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:lightseed/src/ui/screens/main_screen.dart';
+import 'package:lightseed/src/ui/screens/sign_screen.dart';
+
+class AuthStateListener extends StatefulWidget {
+  final Widget child;
+
+  AuthStateListener({required this.child});
+
+  @override
+  AuthStateListenerState createState() => AuthStateListenerState();
+}
+
+class AuthStateListenerState extends State<AuthStateListener> {
+  @override
+  void initState() {
+    super.initState();
+    Supabase.instance.client.auth.onAuthStateChange.listen((data) {
+      final AuthChangeEvent event = data.event;
+      final Session? session = data.session;
+
+      if (event == AuthChangeEvent.signedIn && session != null) {
+        if (!mounted) return;
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(builder: (context) => MyMainScreen()),
+        );
+      } else if (event == AuthChangeEvent.signedOut) {
+        if (!mounted) return;
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(builder: (context) => SignPage()),
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}

--- a/lib/src/logic/auth_state_listener.dart
+++ b/lib/src/logic/auth_state_listener.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:lightseed/src/logic/account_state_screen.dart';
+import 'package:lightseed/src/models/user.dart';
+import 'package:lightseed/src/ui/screens/sign_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -13,48 +17,104 @@ class AuthStateListener extends StatefulWidget {
 }
 
 class AuthStateListenerState extends State<AuthStateListener> {
+  late StreamSubscription<AuthState> _authStateSubscription;
+
   @override
   void initState() {
     super.initState();
-    Supabase.instance.client.auth.onAuthStateChange.listen((data) {
+
+    final session = Supabase.instance.client.auth.currentSession;
+    if (session != null) {
+      _initializeUser(session.user);
+    }
+
+    _authStateSubscription = Supabase.instance.client.auth.onAuthStateChange.listen((data) async {
+      print("AuthStateListener: received auth state change: ${data.event}");
       final AuthChangeEvent event = data.event;
       final Session? session = data.session;
 
-      if (event == AuthChangeEvent.signedIn && session != null) {
-        if (!mounted) return;
-        print('Navigating to main screen');
-        Provider.of<AccountState>(context, listen: false).setUserFromSupabase(session.user);
-/*         Navigator.of(context).pushReplacement(
-          MaterialPageRoute(builder: (context) => MyApp()),
-        ); */
-      } else if (event == AuthChangeEvent.signedOut) {
-        if (!mounted) return;
-        print('Navigating to sign-in screen');
-        Provider.of<AccountState>(context, listen: false).clearUser();
-        Navigator.of(context).pop();
-        /* Navigator.of(context).pushReplacement(
-          MaterialPageRoute(builder: (context) => SignScreen()),
-        ); */
+      switch (event) {
+        case AuthChangeEvent.signedOut:
+          print('AuthStateListener: User signed out');
+          if(!mounted) return;
+          Provider.of<AccountState>(context, listen: false).clearUser();
+          Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => SignScreen()),);
+          
+        case AuthChangeEvent.signedIn:
+          if (session != null) {
+            if (event == AuthChangeEvent.signedIn) {
+              if (!mounted) return;
+              print('AuthStateListener: User signed in with ID: ${session.user.id}');
+              
+              try {
+                // Fetch profile data first
+                final userData = await Supabase.instance.client
+                    .from('profiles')
+                    .select()
+                    .eq('id', session.user.id)
+                    .single();
+                print('Profile data fetched: $userData');
+                
+                final appUser = AppUser(
+                  id: session.user.id,
+                  email: session.user.email ?? '',
+                  fullName: userData['full_name'] ?? '',
+                );
+                
+                if (!mounted) return;
+                Provider.of<AccountState>(context, listen: false).setUser(appUser);
+              } catch (e) {
+                print('Error fetching profile: $e');
+                // Fallback to basic user
+                Provider.of<AccountState>(context, listen: false).setUserFromSupabase(session.user);
+              }
+              
+            } else if (event == AuthChangeEvent.signedOut) {
+              if (!mounted) return;
+              print('AuthStateListener: User signed out');
+              Provider.of<AccountState>(context, listen: false).clearUser();
+              Navigator.of(context).pop();
+            }
+          }
+          
+        default:
+          print('AuthStateListener: Unhandled auth event: $event');
       }
-    });
+    },
+    onError: (error) {
+        print("AuthStateListener: error: $error");
+      },
+  );
+  }
 
-/*     // Check the initial authentication state
-    final session = Supabase.instance.client.auth.currentSession;
-    if (session == null) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        Navigator.of(context).pushReplacement(
-          MaterialPageRoute(builder: (context) => SignScreen()),
-        );
-      });
-    } else {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        Provider.of<AccountState>(context, listen: false).setUserFromSupabase(session.user);
-        Navigator.of(context).pushReplacement(
-          MaterialPageRoute(builder: (context) => MyMainScreen()),
-        );
-      });
-    }  */
+  Future<void> _initializeUser(User supabaseUser) async {
+    try {
+      final userData = await Supabase.instance.client
+          .from('profiles')
+          .select()
+          .eq('id', supabaseUser.id)
+          .single();
+      
+      final appUser = AppUser(
+        id: supabaseUser.id,
+        email: supabaseUser.email ?? '',
+        fullName: userData['full_name'] ?? '',
+      );
+      
+      if (!mounted) return;
+      Provider.of<AccountState>(context, listen: false).setUser(appUser);
+    } catch (e) {
+      print('Error initializing user: $e');
+      if (!mounted) return;
+      Provider.of<AccountState>(context, listen: false).setUserFromSupabase(supabaseUser);
+    }
+  }
 
+  @override
+  void dispose() {
+    print("AuthStateListener: disposing");
+    _authStateSubscription.cancel();
+    super.dispose();
   }
 
   @override

--- a/lib/src/logic/auth_state_listener.dart
+++ b/lib/src/logic/auth_state_listener.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:lightseed/src/logic/account_state_screen.dart';
 import 'package:lightseed/src/models/user.dart';
-import 'package:lightseed/src/ui/screens/sign_screen.dart';
+import 'package:lightseed/src/shared/router.dart';
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -38,7 +37,8 @@ class AuthStateListenerState extends State<AuthStateListener> {
           print('AuthStateListener: User signed out');
           if(!mounted) return;
           Provider.of<AccountState>(context, listen: false).clearUser();
-          Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => SignScreen()),);
+          Navigator.of(context).pop();
+          Navigator.of(context).pushNamedAndRemoveUntil(AppRoutes.signin, (route) => false);
           
         case AuthChangeEvent.signedIn:
           if (session != null) {
@@ -99,6 +99,8 @@ class AuthStateListenerState extends State<AuthStateListener> {
         id: supabaseUser.id,
         email: supabaseUser.email ?? '',
         fullName: userData['full_name'] ?? '',
+        avatarUrl: userData['avatar_url'],
+        darkMode: userData['dark_mode'],
       );
       
       if (!mounted) return;

--- a/lib/src/logic/auth_state_listener.dart
+++ b/lib/src/logic/auth_state_listener.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:lightseed/src/logic/account_state_screen.dart';
+import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import '../shared/router.dart'; // Import the router file
 
 class AuthStateListener extends StatefulWidget {
   final Widget child;
@@ -21,12 +22,39 @@ class AuthStateListenerState extends State<AuthStateListener> {
 
       if (event == AuthChangeEvent.signedIn && session != null) {
         if (!mounted) return;
-        Navigator.pushReplacementNamed(context, AppRoutes.main);
+        print('Navigating to main screen');
+        Provider.of<AccountState>(context, listen: false).setUserFromSupabase(session.user);
+/*         Navigator.of(context).pushReplacement(
+          MaterialPageRoute(builder: (context) => MyApp()),
+        ); */
       } else if (event == AuthChangeEvent.signedOut) {
         if (!mounted) return;
-        Navigator.pushReplacementNamed(context, AppRoutes.signIn);
+        print('Navigating to sign-in screen');
+        Provider.of<AccountState>(context, listen: false).clearUser();
+        Navigator.of(context).pop();
+        /* Navigator.of(context).pushReplacement(
+          MaterialPageRoute(builder: (context) => SignScreen()),
+        ); */
       }
     });
+
+/*     // Check the initial authentication state
+    final session = Supabase.instance.client.auth.currentSession;
+    if (session == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(builder: (context) => SignScreen()),
+        );
+      });
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Provider.of<AccountState>(context, listen: false).setUserFromSupabase(session.user);
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(builder: (context) => MyMainScreen()),
+        );
+      });
+    }  */
+
   }
 
   @override

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -21,7 +21,6 @@ class AppUser {
       email: map['email'],
       fullName: map['full_name'] ?? '',
       avatarUrl: map['avatar_url'],
-      darkMode: map['dark_mode'],
     );
   }
 
@@ -31,8 +30,28 @@ class AppUser {
       'email': email,
       'full_name': fullName,
       'avatar_url': avatarUrl,
+    };
+  }
+  
+  Map<String, dynamic> toProfileData() {
+    return {
+      'id': id,
+      'full_name': fullName,
+      'avatar_url': avatarUrl,
       'dark_mode': darkMode,
     };
+  }
+
+  AppUser copyWith({
+    String? id,
+    String? email,
+    String? fullName,
+  }) {
+    return AppUser(
+      id: id ?? this.id,
+      email: email ?? this.email,
+      fullName: fullName ?? this.fullName,
+    );
   }
 
   // Convert Supabase User to AppUser

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -1,0 +1,23 @@
+class User {
+  final String id;
+  final String email;
+  final String fullName;
+
+  User({required this.id, required this.email, this.fullName = ''});
+
+  factory User.fromMap(Map<String, dynamic> map) {
+    return User(
+      id: map['id'],
+      email: map['email'],
+      fullName: map['full_name'] ?? '',
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'email': email,
+      'full_name': fullName,
+    };
+  }
+}

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -1,15 +1,27 @@
-class User {
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class AppUser {
   final String id;
-  final String email;
-  final String fullName;
+  String? email;
+  String? fullName;
+  String? avatarUrl;
+  bool? darkMode; // Custom field
 
-  User({required this.id, required this.email, this.fullName = ''});
+  AppUser({
+    required this.id,
+    required this.email,
+    this.fullName,
+    this.avatarUrl,
+    this.darkMode,
+  });
 
-  factory User.fromMap(Map<String, dynamic> map) {
-    return User(
+  factory AppUser.fromMap(Map<String, dynamic> map) {
+    return AppUser(
       id: map['id'],
       email: map['email'],
       fullName: map['full_name'] ?? '',
+      avatarUrl: map['avatar_url'],
+      darkMode: map['dark_mode'],
     );
   }
 
@@ -18,6 +30,26 @@ class User {
       'id': id,
       'email': email,
       'full_name': fullName,
+      'avatar_url': avatarUrl,
+      'dark_mode': darkMode,
+    };
+  }
+
+  // Convert Supabase User to AppUser
+  factory AppUser.fromSupabaseUser(User user) {
+    return AppUser(
+      id: user.id,
+      email: user.email,
+      fullName: user.userMetadata?['full_name'],
+      avatarUrl: user.userMetadata?['avatar_url'],
+    );
+  }
+
+  // Convert AppUser to Supabase User metadata
+  Map<String, dynamic> toSupabaseMetadata() {
+    return {
+      'full_name': fullName,
+      'avatar_url': avatarUrl,
     };
   }
 }

--- a/lib/src/shared/animated_routes.dart
+++ b/lib/src/shared/animated_routes.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class FadePageRoute<T> extends PageRouteBuilder<T> {
+  final Widget page;
+  
+  FadePageRoute({required this.page})
+      : super(
+          pageBuilder: (context, animation, secondaryAnimation) => page,
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+            return FadeTransition(
+              opacity: animation,
+              child: child,
+            );
+          },
+          transitionDuration: const Duration(milliseconds: 1000),
+        );
+}

--- a/lib/src/shared/router.dart
+++ b/lib/src/shared/router.dart
@@ -1,16 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:lightseed/src/ui/pages/today_page.dart';
-import 'package:lightseed/src/ui/screens/account_screen.dart';
 import 'package:lightseed/src/ui/screens/main_screen.dart';
-import 'package:lightseed/src/ui/screens/sign_screen.dart';
 import 'package:lightseed/src/ui/screens/splash_screen.dart';
 
 class AppRoutes {
   static const home = '/';
-  static const account = '/account';
-  static const signIn = '/sign';
   static const splash = '/splash';
-  static const main = '/main';
 
   static final List<NavigationDestination> destinations = [
 
@@ -30,11 +24,8 @@ class AppRoutes {
 
   static Map<String, WidgetBuilder> getRoutes(BuildContext context) {
     return {
-      home: (context) => TodayPage(),
-      account: (context) => AccountScreen(),
-      signIn: (context) => SignScreen(),
       splash: (context) => SplashScreen(),
-      main: (context) => MyMainScreen(),
+      home: (context) => MyMainScreen(),
       // Add other routes here
     };
   }

--- a/lib/src/shared/router.dart
+++ b/lib/src/shared/router.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lightseed/src/shared/animated_routes.dart';
 import 'package:lightseed/src/ui/screens/account_screen.dart';
 import 'package:lightseed/src/ui/screens/main_screen.dart';
 import 'package:lightseed/src/ui/screens/sign_screen.dart';
@@ -45,7 +46,7 @@ class AppRoutes {
           builder: (_) => session == null ? SignScreen() : MyMainScreen(),
         );
       case home:
-        return MaterialPageRoute(builder: (_) => MyMainScreen());
+        return FadePageRoute(page: MyMainScreen());
       case signin:
         return MaterialPageRoute(builder: (_) => SignScreen());
       case account:

--- a/lib/src/shared/router.dart
+++ b/lib/src/shared/router.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:lightseed/src/ui/screens/account_screen.dart';
 import 'package:lightseed/src/ui/screens/main_screen.dart';
+import 'package:lightseed/src/ui/screens/sign_screen.dart';
 import 'package:lightseed/src/ui/screens/splash_screen.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class AppRoutes {
   static const home = '/';
   static const splash = '/splash';
+  static const String signin = '/signin';
+  static const String account = '/account';
 
   static final List<NavigationDestination> destinations = [
 
@@ -22,12 +27,32 @@ class AppRoutes {
     ),
   ];
 
-  static Map<String, WidgetBuilder> getRoutes(BuildContext context) {
-    return {
-      splash: (context) => SplashScreen(),
-      home: (context) => MyMainScreen(),
-      // Add other routes here
-    };
+  static Route<dynamic> onGenerateRoute(RouteSettings settings) {
+    print('onGenerateRoute called with: ${settings.name}');
+    // Check if user is authenticated for initial route
+    if (settings.name == splash) {
+      final session = Supabase.instance.client.auth.currentSession;
+      return MaterialPageRoute(
+        builder: (context) => session == null ? SignScreen() : SplashScreen(),
+      );
+    }
+
+    // Map routes directly without using getRoutes
+    switch (settings.name) {
+      case splash:
+        final session = Supabase.instance.client.auth.currentSession;
+        return MaterialPageRoute(
+          builder: (_) => session == null ? SignScreen() : MyMainScreen(),
+        );
+      case home:
+        return MaterialPageRoute(builder: (_) => MyMainScreen());
+      case signin:
+        return MaterialPageRoute(builder: (_) => SignScreen());
+      case account:
+        return MaterialPageRoute(builder: (_) => AccountScreen());
+      default:
+        return MaterialPageRoute(builder: (_) => SignScreen());
+    }
   }
 
 }

--- a/lib/src/shared/router.dart
+++ b/lib/src/shared/router.dart
@@ -1,8 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:lightseed/src/ui/pages/today_page.dart';
+import 'package:lightseed/src/ui/screens/account_screen.dart';
+import 'package:lightseed/src/ui/screens/main_screen.dart';
+import 'package:lightseed/src/ui/screens/sign_screen.dart';
+import 'package:lightseed/src/ui/screens/splash_screen.dart';
 
 class AppRoutes {
   static const home = '/';
-  static const favorites = '/favorites';
+  static const account = '/account';
+  static const signIn = '/sign';
+  static const splash = '/splash';
+  static const main = '/main';
 
   static final List<NavigationDestination> destinations = [
 
@@ -19,4 +27,16 @@ class AppRoutes {
       label: 'Future',
     ),
   ];
+
+  static Map<String, WidgetBuilder> getRoutes(BuildContext context) {
+    return {
+      home: (context) => TodayPage(),
+      account: (context) => AccountScreen(),
+      signIn: (context) => SignScreen(),
+      splash: (context) => SplashScreen(),
+      main: (context) => MyMainScreen(),
+      // Add other routes here
+    };
+  }
+
 }

--- a/lib/src/ui/app.dart
+++ b/lib/src/ui/app.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:lightseed/src/logic/today_page_state.dart';
+import 'package:lightseed/src/shared/router.dart';
 import 'package:lightseed/src/ui/theme/theme.dart';
 import 'package:lightseed/src/ui/theme/util.dart';
 import 'package:provider/provider.dart';
-import 'screens/main_screen.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
@@ -12,18 +12,19 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
       create: (context) => TodayPageState(),
-      child: buildMaterialApp(context, MyMainScreen()),
+      child: buildMaterialApp(context),
     );
   }
 }
 
-MaterialApp buildMaterialApp(BuildContext context, Widget home) {
+MaterialApp buildMaterialApp(BuildContext context) {
   final brightness = View.of(context).platformDispatcher.platformBrightness;
   return MaterialApp(
     debugShowCheckedModeBanner: false,
     title: "LightSeed",
     theme: _buildThemeData(context, brightness),
-    home: home,
+    onGenerateRoute: AppRoutes.onGenerateRoute,
+    initialRoute: AppRoutes.splash,
   );
 }
 

--- a/lib/src/ui/elements/snackbar.dart
+++ b/lib/src/ui/elements/snackbar.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+extension ContextExtension on BuildContext {
+  void showSnackBar(String message, {bool isError = false}) {
+    ScaffoldMessenger.of(this).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: isError
+            ? Theme.of(this).colorScheme.error
+            : Theme.of(this).snackBarTheme.backgroundColor,
+      ),
+    );
+  }
+}

--- a/lib/src/ui/pages/today_page.dart
+++ b/lib/src/ui/pages/today_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:lightseed/src/logic/account_state_screen.dart';
 import 'package:lightseed/src/models/affirmation.dart';
-import 'package:lightseed/src/ui/screens/account_screen.dart';
+import 'package:lightseed/src/shared/router.dart';
 import 'package:provider/provider.dart';
 import '../../logic/today_page_state.dart';
 import '../elements/animated_text_card.dart';
@@ -52,12 +52,7 @@ class TodayPage extends StatelessWidget {
           IconButton(
             icon: Icon(Icons.person),
             onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => AccountScreen(),
-                ),
-              );
+              Navigator.of(context).pushNamed(AppRoutes.account);
             },
           ),
         ],

--- a/lib/src/ui/pages/today_page.dart
+++ b/lib/src/ui/pages/today_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:lightseed/src/logic/account_state_screen.dart';
 import 'package:lightseed/src/models/affirmation.dart';
+import 'package:lightseed/src/ui/screens/account_screen.dart';
 import 'package:provider/provider.dart';
 import '../../logic/today_page_state.dart';
 import '../elements/animated_text_card.dart';
@@ -9,6 +11,7 @@ class TodayPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     var appState = context.watch<TodayPageState>();
+    var accountState = context.watch<AccountState>();
     Affirmation affirmation = appState.getCurrentAffirmation();
 
     IconData icon;
@@ -20,14 +23,23 @@ class TodayPage extends StatelessWidget {
 
     String getTitle() {
       int hour = DateTime.now().hour;
+      String greeting;
       if (hour < 12) {
-        return 'Good morning';
+        greeting = 'Good morning';
       } else if (hour < 17) {
-        return 'Good afternoon';
+        greeting = 'Good afternoon';
       } else if (hour < 20) {
-        return 'Good evening';
+        greeting = 'Good evening';
       } else {
-        return 'Good night';
+        greeting = 'Good night';
+      }
+
+      String? fullName = accountState.user?.fullName;
+      if (fullName != null && fullName.isNotEmpty) {
+        String firstName = fullName.split(' ').first;
+        return '$greeting, $firstName';
+      } else {
+        return greeting;
       }
     }
 
@@ -36,6 +48,19 @@ class TodayPage extends StatelessWidget {
         title: Text(getTitle()),
         toolbarHeight: 100, // Set the height of the AppBar
         centerTitle: true,
+        actions: [
+          IconButton(
+            icon: Icon(Icons.person),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => AccountScreen(),
+                ),
+              );
+            },
+          ),
+        ],
       ),
       body: Center(
         child: Column(

--- a/lib/src/ui/screens/account_screen.dart
+++ b/lib/src/ui/screens/account_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:lightseed/src/shared/router.dart';
+import 'package:provider/provider.dart';
+import '../../logic/account_state_screen.dart';
+
+class AccountScreen extends StatelessWidget {
+  final bool isFromSignUp;
+
+  const AccountScreen({super.key, this.isFromSignUp = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final user = Provider.of<AccountState>(context).user;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Account'),
+        leading: isFromSignUp ? null : BackButton(),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            CircleAvatar(
+              radius: 40,
+              child: Icon(Icons.person, size: 40),
+            ),
+            SizedBox(height: 16),
+            Text(user?.email ?? '', style: TextStyle(fontSize: 18)),
+            TextField(
+              decoration: InputDecoration(labelText: 'Full Name'),
+              controller: TextEditingController(text: user?.fullName),
+              onChanged: (value) {
+                user?.fullName = value;
+              },
+            ),
+            Spacer(),
+            if (isFromSignUp)
+              ElevatedButton(
+                onPressed: () async {
+                  // Save user data and navigate to the main app
+                  await Provider.of<AccountState>(context, listen: false).saveUserData();
+                  if (!context.mounted) return;
+                  Navigator.pushReplacementNamed(context, AppRoutes.home);
+                },
+                child: Text('Complete Profile'),
+              )
+            else
+              Column(
+                children: [
+                  ElevatedButton(
+                    onPressed: () async {
+                      // Save user data
+                      await Provider.of<AccountState>(context, listen: false).saveUserData();
+                    },
+                    child: Text('Save'),
+                  ),
+                  SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () {
+                      Provider.of<AccountState>(context, listen: false).signOut(context);
+                    },
+                    child: Text('Sign Out'),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/ui/screens/account_screen.dart
+++ b/lib/src/ui/screens/account_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lightseed/src/logic/auth_logic.dart';
-import 'package:lightseed/src/ui/screens/sign_screen.dart';
+import 'package:lightseed/src/shared/router.dart';
 import 'package:provider/provider.dart';
 import 'package:lightseed/src/logic/account_state_screen.dart';
 
@@ -19,7 +19,7 @@ class AccountScreen extends StatelessWidget {
     // if there is no instance of user, navigate to SignScreen
     if (user == null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => SignScreen()),);
+        Navigator.of(context).pushNamed(AppRoutes.signin);
       });
       return Container();
     }
@@ -65,6 +65,11 @@ class AccountScreen extends StatelessWidget {
                     await AuthLogic.signOut();
                     if (context.mounted) {
                       Navigator.of(context).pop();
+                      // Pop to root and replace with SignScreen
+                      Navigator.of(context).pushNamedAndRemoveUntil(
+                        AppRoutes.signin,
+                        (route) => false
+                      );
                     }
                   },
                   child: Text('Sign Out'),

--- a/lib/src/ui/screens/account_screen.dart
+++ b/lib/src/ui/screens/account_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lightseed/src/shared/router.dart';
+import 'package:lightseed/src/logic/auth_logic.dart';
 import 'package:provider/provider.dart';
 import '../../logic/account_state_screen.dart';
 
@@ -11,6 +11,7 @@ class AccountScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final user = Provider.of<AccountState>(context).user;
+    final fullNameController = TextEditingController(text: user?.fullName);
 
     return Scaffold(
       appBar: AppBar(
@@ -29,7 +30,7 @@ class AccountScreen extends StatelessWidget {
             Text(user?.email ?? '', style: TextStyle(fontSize: 18)),
             TextField(
               decoration: InputDecoration(labelText: 'Full Name'),
-              controller: TextEditingController(text: user?.fullName),
+              controller: fullNameController,
               onChanged: (value) {
                 user?.fullName = value;
               },
@@ -41,7 +42,10 @@ class AccountScreen extends StatelessWidget {
                   // Save user data and navigate to the main app
                   await Provider.of<AccountState>(context, listen: false).saveUserData();
                   if (!context.mounted) return;
-                  Navigator.pushReplacementNamed(context, AppRoutes.home);
+                  Navigator.of(context).pop();
+                  /* Navigator.of(context).pushReplacement(
+                    MaterialPageRoute(builder: (context) => MyApp()),
+                  ); */
                 },
                 child: Text('Complete Profile'),
               )
@@ -52,15 +56,20 @@ class AccountScreen extends StatelessWidget {
                     onPressed: () async {
                       // Save user data
                       await Provider.of<AccountState>(context, listen: false).saveUserData();
+                      if (!context.mounted) return;
+                      Navigator.of(context).pop();
                     },
                     child: Text('Save'),
                   ),
                   SizedBox(height: 16),
                   ElevatedButton(
-                    onPressed: () {
-                      Provider.of<AccountState>(context, listen: false).signOut(context);
-                    },
-                    child: Text('Sign Out'),
+                  onPressed: () async {
+                    await AuthLogic.signOut();
+                    if (context.mounted) {
+                      Navigator.of(context).pop();
+                    }
+                  },
+                  child: Text('Sign Out'),
                   ),
                 ],
               ),

--- a/lib/src/ui/screens/sign_screen.dart
+++ b/lib/src/ui/screens/sign_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:lightseed/src/logic/auth_logic.dart';
 import 'package:lightseed/src/ui/elements/snackbar.dart';
+import 'package:lightseed/src/ui/app.dart';
 
 class SignScreen extends StatefulWidget {
   @override
@@ -36,17 +37,20 @@ class SignScreenState extends State<SignScreen> {
               onPressed: () async {
                 final email = emailController.text;
                 final password = passwordController.text;
+                String? response;
                 if (isSignUp) {
-                  final response = await AuthLogic.signUp(email, password);
-                  if (response != null) {
-                    context.showSnackBar(response, isError: true);
-                  }
+                  response = await AuthLogic.signUp(email, password);
                 } else {
-                  final response = await AuthLogic.signIn(email, password);
-                  if (response != null) {
-                    context.showSnackBar(response, isError: true);
-                  }
+                  response = await AuthLogic.signIn(email, password);
                 }
+                
+                if (response != null) {
+                  if (context.mounted) {context.showSnackBar(response, isError: true);}
+                }
+                if (context.mounted){
+                  Navigator.of(context).pushReplacement(
+                    MaterialPageRoute(builder: (context) => MyApp()),
+                );}
               },
               child: Text(isSignUp ? 'Sign Up' : 'Login'),
             ),

--- a/lib/src/ui/screens/sign_screen.dart
+++ b/lib/src/ui/screens/sign_screen.dart
@@ -1,15 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:lightseed/src/logic/auth_logic.dart';
+import 'package:lightseed/src/ui/elements/snackbar.dart';
 
-class SignUpPage extends StatelessWidget {
+class SignPage extends StatefulWidget {
+  @override
+  SignPageState createState() => SignPageState();
+}
+
+class SignPageState extends State<SignPage> {
   final TextEditingController emailController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
+  bool isSignUp = true;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Sign Up'),
+        title: Text(isSignUp ? 'Sign Up' : 'Login'),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -29,15 +36,33 @@ class SignUpPage extends StatelessWidget {
               onPressed: () async {
                 final email = emailController.text;
                 final password = passwordController.text;
-                await AuthLogic.signUp(email, password);
+                if (isSignUp) {
+                  final response = await AuthLogic.signUp(email, password);
+                  if (response != null) {
+                    context.showSnackBar(response, isError: true);
+                  }
+                } else {
+                  final response = await AuthLogic.signIn(email, password);
+                  if (response != null) {
+                    context.showSnackBar(response, isError: true);
+                  }
+                }
               },
-              child: Text('Sign Up'),
+              child: Text(isSignUp ? 'Sign Up' : 'Login'),
             ),
             ElevatedButton(
               onPressed: () async {
                 await AuthLogic.signInWithGoogle();
               },
-              child: Text('Sign Up with Google'),
+              child: Text('Sign In with Google'),
+            ),
+            TextButton(
+              onPressed: () {
+                setState(() {
+                  isSignUp = !isSignUp;
+                });
+              },
+              child: Text(isSignUp ? 'Already have an account? Login' : 'Don\'t have an account? Sign Up'),
             ),
           ],
         ),

--- a/lib/src/ui/screens/sign_screen.dart
+++ b/lib/src/ui/screens/sign_screen.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:lightseed/src/logic/auth_logic.dart';
 import 'package:lightseed/src/ui/elements/snackbar.dart';
 
-class SignPage extends StatefulWidget {
+class SignScreen extends StatefulWidget {
   @override
-  SignPageState createState() => SignPageState();
+  SignScreenState createState() => SignScreenState();
 }
 
-class SignPageState extends State<SignPage> {
+class SignScreenState extends State<SignScreen> {
   final TextEditingController emailController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
   bool isSignUp = true;

--- a/lib/src/ui/screens/sign_screen.dart
+++ b/lib/src/ui/screens/sign_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:lightseed/src/logic/auth_logic.dart';
-import 'package:lightseed/src/ui/elements/snackbar.dart';
 import 'package:lightseed/src/ui/app.dart';
+import 'package:lightseed/src/ui/elements/snackbar.dart';
 
 class SignScreen extends StatefulWidget {
   @override
@@ -48,9 +48,10 @@ class SignScreenState extends State<SignScreen> {
                   if (context.mounted) {context.showSnackBar(response, isError: true);}
                 }
                 if (context.mounted){
-                  Navigator.of(context).pushReplacement(
+                   Navigator.of(context).pushReplacement(
                     MaterialPageRoute(builder: (context) => MyApp()),
-                );}
+                ); 
+                }
               },
               child: Text(isSignUp ? 'Sign Up' : 'Login'),
             ),

--- a/lib/src/ui/screens/signup_screen.dart
+++ b/lib/src/ui/screens/signup_screen.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:lightseed/src/logic/auth_logic.dart';
+
+class SignUpPage extends StatelessWidget {
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Sign Up'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: emailController,
+              decoration: InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: passwordController,
+              decoration: InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                final email = emailController.text;
+                final password = passwordController.text;
+                await AuthLogic.signUp(email, password);
+              },
+              child: Text('Sign Up'),
+            ),
+            ElevatedButton(
+              onPressed: () async {
+                await AuthLogic.signInWithGoogle();
+              },
+              child: Text('Sign Up with Google'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/ui/screens/splash_screen.dart
+++ b/lib/src/ui/screens/splash_screen.dart
@@ -2,9 +2,7 @@ import 'package:animated_text_kit/animated_text_kit.dart';
 import 'package:flutter/material.dart';
 import 'package:lightseed/src/models/quote.dart';
 import 'package:lightseed/src/ui/app.dart';
-import 'package:lightseed/src/ui/screens/sign_screen.dart';
 import 'package:lottie/lottie.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
 class SplashScreen extends StatefulWidget {
   @override
@@ -26,40 +24,20 @@ class SplashScreenState extends State<SplashScreen> {
     await Future.delayed(Duration(seconds: 4), () {});
     if (!mounted) return;
     
-    final session = Supabase.instance.client.auth.currentSession;
-    
-    // test if the user is already authenticated on Supabase
-    if (session != null) {
-      Navigator.pushReplacement(
-        context,
-        PageRouteBuilder(
-          pageBuilder: (context, animation, secondaryAnimation) => MyApp(),
-          transitionDuration: const Duration(milliseconds: 1000),
-          transitionsBuilder: (context, animation, secondaryAnimation, child) {
-            return FadeTransition(
-              opacity: animation,
-              child: child,
-            );
-          },
-        ),
-      );
-    } else {
-      Navigator.pushReplacement(
-        context,
-        PageRouteBuilder(
-          pageBuilder: (context, animation, secondaryAnimation) => SignScreen(),
-          transitionDuration: const Duration(milliseconds: 1000),
-          transitionsBuilder: (context, animation, secondaryAnimation, child) {
-            return FadeTransition(
-              opacity: animation,
-              child: child,
-            );
-          },
-        ),
-      );
-    }
-  }
-
+    Navigator.pushReplacement(
+      context,
+      PageRouteBuilder(
+        pageBuilder: (context, animation, secondaryAnimation) => MyApp(),
+        transitionDuration: const Duration(milliseconds: 1000),
+        transitionsBuilder: (context, animation, secondaryAnimation, child) {
+          return FadeTransition(
+            opacity: animation,
+            child: child,
+          );
+        },
+      ),
+    ); 
+  } 
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/ui/screens/splash_screen.dart
+++ b/lib/src/ui/screens/splash_screen.dart
@@ -47,7 +47,7 @@ class SplashScreenState extends State<SplashScreen> {
       Navigator.pushReplacement(
         context,
         PageRouteBuilder(
-          pageBuilder: (context, animation, secondaryAnimation) => SignPage(),
+          pageBuilder: (context, animation, secondaryAnimation) => SignScreen(),
           transitionDuration: const Duration(milliseconds: 1000),
           transitionsBuilder: (context, animation, secondaryAnimation, child) {
             return FadeTransition(

--- a/lib/src/ui/screens/splash_screen.dart
+++ b/lib/src/ui/screens/splash_screen.dart
@@ -1,7 +1,7 @@
 import 'package:animated_text_kit/animated_text_kit.dart';
 import 'package:flutter/material.dart';
 import 'package:lightseed/src/models/quote.dart';
-import 'package:lightseed/src/ui/app.dart';
+import 'package:lightseed/src/shared/router.dart';
 import 'package:lottie/lottie.dart';
 
 class SplashScreen extends StatefulWidget {
@@ -23,7 +23,9 @@ class SplashScreenState extends State<SplashScreen> {
     // Simulate some background initialization work
     await Future.delayed(Duration(seconds: 4), () {});
     if (!mounted) return;
-    
+
+    Navigator.pushNamedAndRemoveUntil(context, AppRoutes.home, (route) => false);
+    /* 
     Navigator.pushReplacement(
       context,
       PageRouteBuilder(
@@ -36,7 +38,7 @@ class SplashScreenState extends State<SplashScreen> {
           );
         },
       ),
-    ); 
+    );  */
   } 
 
   @override

--- a/lib/src/ui/screens/splash_screen.dart
+++ b/lib/src/ui/screens/splash_screen.dart
@@ -2,7 +2,9 @@ import 'package:animated_text_kit/animated_text_kit.dart';
 import 'package:flutter/material.dart';
 import 'package:lightseed/src/models/quote.dart';
 import 'package:lightseed/src/ui/app.dart';
+import 'package:lightseed/src/ui/screens/sign_screen.dart';
 import 'package:lottie/lottie.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class SplashScreen extends StatefulWidget {
   @override
@@ -23,20 +25,41 @@ class SplashScreenState extends State<SplashScreen> {
     // Simulate some background initialization work
     await Future.delayed(Duration(seconds: 4), () {});
     if (!mounted) return;
-    Navigator.pushReplacement(
-      context,
-      PageRouteBuilder(
-        pageBuilder: (context, animation, secondaryAnimation) => MyApp(),
-        transitionDuration: const Duration(milliseconds: 1000),
-        transitionsBuilder: (context, animation, secondaryAnimation, child) {
-          return FadeTransition(
-            opacity: animation,
-            child: child,
-          );
-        },
-      ),
-    );
+    
+    final session = Supabase.instance.client.auth.currentSession;
+    
+    // test if the user is already authenticated on Supabase
+    if (session != null) {
+      Navigator.pushReplacement(
+        context,
+        PageRouteBuilder(
+          pageBuilder: (context, animation, secondaryAnimation) => MyApp(),
+          transitionDuration: const Duration(milliseconds: 1000),
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+            return FadeTransition(
+              opacity: animation,
+              child: child,
+            );
+          },
+        ),
+      );
+    } else {
+      Navigator.pushReplacement(
+        context,
+        PageRouteBuilder(
+          pageBuilder: (context, animation, secondaryAnimation) => SignPage(),
+          transitionDuration: const Duration(milliseconds: 1000),
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+            return FadeTransition(
+              opacity: animation,
+              child: child,
+            );
+          },
+        ),
+      );
+    }
   }
+
 
   @override
   Widget build(BuildContext context) {
@@ -56,6 +79,7 @@ class SplashScreenState extends State<SplashScreen> {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
+                    // quote phrase
                     SizedBox(
                       height: 250,
                       child: DefaultTextStyle(
@@ -70,6 +94,7 @@ class SplashScreenState extends State<SplashScreen> {
                       ),
                     ),
                     
+                    // quote author
                     SizedBox(
                       height: 50,
                       child: DefaultTextStyle(
@@ -83,6 +108,7 @@ class SplashScreenState extends State<SplashScreen> {
                       ),
                     ),
                     const SizedBox(height: 20),
+                    // Lottie animation
                     SizedBox(
                       width: 300,
                       child: Lottie.asset(

--- a/lib/src/ui/screens/splash_screen.dart
+++ b/lib/src/ui/screens/splash_screen.dart
@@ -25,20 +25,6 @@ class SplashScreenState extends State<SplashScreen> {
     if (!mounted) return;
 
     Navigator.pushNamedAndRemoveUntil(context, AppRoutes.home, (route) => false);
-    /* 
-    Navigator.pushReplacement(
-      context,
-      PageRouteBuilder(
-        pageBuilder: (context, animation, secondaryAnimation) => MyApp(),
-        transitionDuration: const Duration(milliseconds: 1000),
-        transitionsBuilder: (context, animation, secondaryAnimation, child) {
-          return FadeTransition(
-            opacity: animation,
-            child: child,
-          );
-        },
-      ),
-    );  */
   } 
 
   @override

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,14 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <gtk/gtk_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,8 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  gtk
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,12 +6,14 @@ import FlutterMacOS
 import Foundation
 
 import app_links
+import google_sign_in_ios
 import path_provider_foundation
 import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
+  FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,14 @@
 import FlutterMacOS
 import Foundation
 
+import app_links
 import path_provider_foundation
 import shared_preferences_foundation
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.14'
+platform :osx, '10.15'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - app_links (1.0.0):
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - path_provider_foundation (0.0.1):
     - Flutter
@@ -6,24 +8,34 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
 
 DEPENDENCIES:
+  - app_links (from `Flutter/ephemeral/.symlinks/plugins/app_links/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
 EXTERNAL SOURCES:
+  app_links:
+    :path: Flutter/ephemeral/.symlinks/plugins/app_links/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   path_provider_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
+  app_links: 10e0a0ab602ffaf34d142cd4862f29d34b303b2a
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
 
 PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367
 

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -260,7 +260,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1620;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C80D4294CF70F00263BE5 = {

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -69,7 +69,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* lightseed.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = lightseed.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* LightSeed.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LightSeed.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -144,7 +144,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* lightseed.app */,
+				33CC10ED2044A3C60003C045 /* LightSeed.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -195,7 +195,6 @@
 				0E8866F74FBE222550433732 /* Pods-RunnerTests.release.xcconfig */,
 				ABA2F2A6EC565123CFBD5296 /* Pods-RunnerTests.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -241,6 +240,7 @@
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
 				C3A3728087B6646B8277FB32 /* [CP] Embed Pods Frameworks */,
+				166D4ED21E8A169A1AC653E9 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -249,7 +249,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* lightseed.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* LightSeed.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -260,7 +260,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1510;
+				LastUpgradeCheck = 1620;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C80D4294CF70F00263BE5 = {
@@ -323,6 +323,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		166D4ED21E8A169A1AC653E9 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -478,8 +495,9 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstFlutterApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lightseed.lightseed.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/lightseed.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/lightseed";
@@ -493,8 +511,9 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstFlutterApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lightseed.lightseed.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/lightseed.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/lightseed";
@@ -508,8 +527,9 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstFlutterApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lightseed.lightseed.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/lightseed.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/lightseed";
@@ -579,6 +599,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lightseed.lightseed;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -588,6 +610,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Profile;
@@ -711,6 +734,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lightseed.lightseed;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -731,6 +756,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lightseed.lightseed;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -740,6 +767,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -748,6 +776,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1620"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1510"
+   LastUpgradeVersion = "1620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "lightseed.app"
+               BuildableName = "LightSeed.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "lightseed.app"
+            BuildableName = "LightSeed.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "lightseed.app"
+            BuildableName = "LightSeed.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -82,7 +82,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "lightseed.app"
+            BuildableName = "LightSeed.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -22,17 +22,25 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>$(PRODUCT_COPYRIGHT)</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-<!-- Other keys and values -->
-    <key>NSAppTransportSecurity</key>
-    <dict>
-        <key>NSAllowsArbitraryLoads</key>
-        <true/>
-    </dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.847143055036-6tiu7qu9afa5tjipsdioukk41afdsi54</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -42,5 +42,17 @@
 			</array>
 		</dict>
 	</array>
+	<!-- Add this array for Deep Links -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+		<key>CFBundleTypeRole</key>
+		<string>Editor</string>
+		<key>CFBundleURLSchemes</key>
+		<array>
+			<string>com.lightseed.lightseed</string>
+		</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -180,7 +180,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -200,6 +200,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.2.1"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      sha256: "55580f436822d64c8ff9a77e37d61f5fb1e6c7ec9d632a43ee324e2a05c3c6c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3"
+  google_sign_in:
+    dependency: "direct main"
+    description:
+      name: google_sign_in
+      sha256: fad6ddc80c427b0bba705f2116204ce1173e09cf299f85e053d57a55e5b2dd56
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.2"
+  google_sign_in_android:
+    dependency: transitive
+    description:
+      name: google_sign_in_android
+      sha256: "3b96f9b6cf61915f73cbe1218a192623e296a9b8b31965702503649477761e36"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.34"
+  google_sign_in_ios:
+    dependency: transitive
+    description:
+      name: google_sign_in_ios
+      sha256: "83f015169102df1ab2905cf8abd8934e28f87db9ace7a5fa676998842fed228a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.7.8"
+  google_sign_in_platform_interface:
+    dependency: transitive
+    description:
+      name: google_sign_in_platform_interface
+      sha256: "1f6e5787d7a120cc0359ddf315c92309069171306242e181c09472d1b00a2971"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.5"
+  google_sign_in_web:
+    dependency: transitive
+    description:
+      name: google_sign_in_web
+      sha256: ada595df6c30cead48e66b1f3a050edf0c5cf2ba60c185d69690e08adcc6281b
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.4+3"
   gotrue:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.2"
+  app_links:
+    dependency: transitive
+    description:
+      name: app_links
+      sha256: "433df2e61b10519407475d7f69e470789d23d593f28224c38ba1068597be7950"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   archive:
     dependency: transitive
     description:
@@ -152,6 +184,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  functions_client:
+    dependency: transitive
+    description:
+      name: functions_client
+      sha256: "61597ed93be197b1be6387855e4b760e6aac2355fcfc4df6d20d2b4579982158"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   google_fonts:
     dependency: "direct main"
     description:
@@ -160,6 +200,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.2.1"
+  gotrue:
+    dependency: transitive
+    description:
+      name: gotrue
+      sha256: d6362dff9a54f8c1c372bb137c858b4024c16407324d34e6473e59623c9b9f50
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   http:
     dependency: "direct main"
     description:
@@ -200,6 +256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  jwt_decode:
+    dependency: transitive
+    description:
+      name: jwt_decode
+      sha256: d2e9f68c052b2225130977429d30f187aa1981d789c76ad104a32243cfdebfbb
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -232,6 +296,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   lottie:
     dependency: "direct main"
     description:
@@ -264,6 +336,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   nested:
     dependency: transitive
     description:
@@ -352,6 +432,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  postgrest:
+    dependency: transitive
+    description:
+      name: postgrest
+      sha256: b74dc0f57b5dca5ce9f57a54b08110bf41d6fc8a0483c0fec10c79e9aa0fb2bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   provider:
     dependency: "direct main"
     description:
@@ -360,6 +448,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
+  realtime_client:
+    dependency: transitive
+    description:
+      name: realtime_client
+      sha256: "1bfcb7455fdcf15953bf18ac2817634ea5b8f7f350c7e8c9873141a3ee2c3e9c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  retry:
+    dependency: transitive
+    description:
+      name: retry
+      sha256: "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -437,6 +549,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.0"
+  storage_client:
+    dependency: transitive
+    description:
+      name: storage_client
+      sha256: d80d34f0aa60e5199646bc301f5750767ee37310c2ecfe8d4bbdd29351e09ab0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   stream_channel:
     dependency: transitive
     description:
@@ -453,6 +573,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  supabase:
+    dependency: transitive
+    description:
+      name: supabase
+      sha256: "270f63cd87a16578fee87e40cbf61062e8cdbce68d5e723e665f4651d70ddd8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  supabase_flutter:
+    dependency: "direct main"
+    description:
+      name: supabase_flutter
+      sha256: ca8dfe3d4b109e7338cdf7778f3ec2c660a0178006876bfac343eb39b0f3d1e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.8.3"
   term_glyph:
     dependency: transitive
     description:
@@ -477,6 +613,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: transitive
+    description:
+      name: url_launcher
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "6fc2f56536ee873eeb867ad176ae15f304ccccc357848b351f6f0d8d4a40d193"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.14"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "16a513b6c12bb419304e72ea0ae2ab4fed569920d1c7cb850263fe3acc824626"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "3ba963161bd0fe395917ba881d320b9c4f6dd3c4a233da62ab18a5025c85f1e9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   vector_math:
     dependency: transitive
     description:
@@ -501,6 +701,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
+  web_socket_channel:
+    dependency: transitive
+    description:
+      name: web_socket_channel
+      sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   xdg_directories:
     dependency: transitive
     description:
@@ -525,6 +741,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  yet_another_json_isolate:
+    dependency: transitive
+    description:
+      name: yet_another_json_isolate
+      sha256: "56155e9e0002cc51ea7112857bbcdc714d4c35e176d43e4d3ee233009ff410c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
 sdks:
   dart: ">=3.6.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -10,7 +10,7 @@ packages:
     source: hosted
     version: "4.2.2"
   app_links:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: app_links
       sha256: "433df2e61b10519407475d7f69e470789d23d593f28224c38ba1068597be7950"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   shared_preferences: ^2.4.0
   path_provider: ^2.1.5
   supabase_flutter: ^2.8.3
+  google_sign_in: ^6.2.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   animated_text_kit: ^4.2.2
   shared_preferences: ^2.4.0
   path_provider: ^2.1.5
+  supabase_flutter: ^2.8.3
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
 
   english_words: ^4.0.0
   provider: ^6.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
+  app_links: ^6.3.3
 
   english_words: ^4.0.0
   provider: ^6.1.2

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <app_links/app_links_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AppLinksPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,8 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  app_links
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
### Changes
- Add Sign up with email and password
- Add Sign in with email and password
- Add Sign in with Google [needs to be QAed throughly, not working on local dev env]
- Add deepling support and routes for screens
- Add FadeIn Animation class to re-use code and apply animation to any other screens
- Add Account screen accessible from Today's page (main screen)
- Add Sign Out button
- Add "Complete profile" state of the account screen to be prompted after signup [redirect not implemented yet]
- Add customisation of Today's page if Full name is known
- Cleaned up router.dart to handle navigation properly
- Fixed SplashScreen navigation flow
- Fixed authentication state handling from previous commit on this branch

### Next Steps
Add email update feature
Test edge cases for auth flow
Add loading states